### PR TITLE
MangoHud v0.6.8 (branch 21.08)

### DIFF
--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml
@@ -11,6 +11,7 @@
   <project_license>MIT</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="0.6.8" date="2022-08-01"/>
     <release version="0.6.7-1" date="2022-05-13"/>
     <release version="0.6.6-1" date="2021-10-23"/>
     <release version="0.6.5" date="2021-07-08"/>

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -29,7 +29,6 @@ modules:
       - -Duse_system_vulkan=enabled
       - -Dvulkan_datadir=/usr/share
       - -Dwith_xnvctrl=enabled
-      - -Dwith_libdrm_amdgpu=disabled
       - -Dappend_libdir_mangohud=false
     sources: &mangohud-sources
       - type: archive

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -148,7 +148,14 @@ modules:
     modules:
 
       - name: glew-32bit
-        build-options: *i386-build-options
+        build-options: 
+          arch:
+            x86_64: *i386-build-options
+          make-args:
+            - CC=ccache i686-unknown-linux-gnu-gcc
+            - CXX=ccache i686-unknown-linux-gnu-g++
+            - LD=i686-unknown-linux-gnu-gcc
+            - AR=i686-unknown-linux-gnu-ar
         no-autogen: true
         make-args: *glew-make-args
         make-install-args: *glew-make-args

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -11,19 +11,34 @@ sdk-extensions:
 build-options:
   prefix: /usr/lib/extensions/vulkan/MangoHud
   prepend-path: /usr/lib/extensions/vulkan/MangoHud/bin
-  prepend-pkg-config-path: /usr/lib/extensions/vulkan/MangoHud/lib/pkgconfig
+  prepend-pkg-config-path: /usr/lib/extensions/vulkan/MangoHud/share/pkgconfig
   env:
     PYTHONPATH: /usr/lib/extensions/vulkan/MangoHud/lib/python3.9/site-packages
     C_INCLUDE_PATH: /usr/lib/extensions/vulkan/MangoHud/include
     CPLUS_INCLUDE_PATH: /usr/lib/extensions/vulkan/MangoHud/include
   strip: true
+x-arch-build-options:
+  x86_64: &x86_64-build-options
+    libdir: /usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu
+    prepend-pkg-config-path: /usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu/pkgconfig
+    ldflags: -Wl,-rpath=/usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu
+    env:
+      FLATPAK_LIBDIR: /usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu
+  i386: &i386-build-options
+    libdir: /usr/lib/extensions/vulkan/MangoHud/lib/i386-linux-gnu
+    prepend-pkg-config-path: /usr/lib/extensions/vulkan/MangoHud/lib/i386-linux-gnu/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
+    ldflags: -Wl,-rpath=/usr/lib/extensions/vulkan/MangoHud/lib/i386-linux-gnu
+    append-path: /usr/lib/sdk/toolchain-i386/bin
+    env:
+      FLATPAK_LIBDIR: /usr/lib/extensions/vulkan/MangoHud/lib/i386-linux-gnu
+      CC: ccache i686-unknown-linux-gnu-gcc
+      CXX: ccache i686-unknown-linux-gnu-g++
 cleanup:
   - /include
 modules:
 
   - name: MangoHud
-    build-options:
-      libdir: lib/x86_64-linux-gnu
+    build-options: *x86_64-build-options
     buildsystem: meson
     config-opts: &mangohud-config-opts
       - -Duse_system_vulkan=enabled
@@ -47,14 +62,12 @@ modules:
       - python3-mako.json
 
       - name: libNVCtrl
-        build-options:
-          env:
-            LIB: lib/x86_64-linux-gnu
+        build-options: *x86_64-build-options
         no-autogen: true
         no-make-install: true
         build-commands: &libNVCtrl-build-commands
-          - mkdir -p ${FLATPAK_DEST}/$LIB
-          - cp -a libXNVCtrl.so* ${FLATPAK_DEST}/$LIB/
+          - mkdir -p ${FLATPAK_LIBDIR}
+          - cp -a libXNVCtrl.so* ${FLATPAK_LIBDIR}
           - install -D *.h -t ${FLATPAK_DEST}/include/NVCtrl
         subdir: src/libXNVCtrl
         sources: &libNVCtrl-sources
@@ -71,25 +84,14 @@ modules:
               version-query: .[0].name
 
   - name: MangoHud-32bit
-    build-options:
-      prepend-pkg-config-path: /usr/lib/i386-linux-gnu/pkgconfig
-      append-path: /usr/lib/sdk/toolchain-i386/bin
-      env:
-        CC: ccache i686-unknown-linux-gnu-gcc
-        CXX: ccache i686-unknown-linux-gnu-g++
-      libdir: lib/i386-linux-gnu
+    build-options: *i386-build-options
     buildsystem: meson
     config-opts: *mangohud-config-opts
     sources: *mangohud-sources
     modules:
 
       - name: libNVCtrl-32bit
-        build-options:
-          append-path: /usr/lib/sdk/toolchain-i386/bin
-          env:
-            CC: ccache i686-unknown-linux-gnu-gcc
-            CXX: ccache i686-unknown-linux-gnu-g++
-            LIB: lib/i386-linux-gnu
+        build-options: *i386-build-options
         no-autogen: true
         no-make-install: true
         build-commands: *libNVCtrl-build-commands

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -38,13 +38,18 @@ cleanup:
 modules:
 
   - name: MangoHud
-    build-options: *x86_64-build-options
+    build-options:
+      arch:
+        x86_64: *x86_64-build-options
+      config-opts:
+        - -Dmangoapp=true
     buildsystem: meson
     config-opts: &mangohud-config-opts
       - -Duse_system_vulkan=enabled
       - -Dvulkan_datadir=/usr/share
       - -Dwith_xnvctrl=enabled
       - -Dappend_libdir_mangohud=false
+      - -Dmangoapp_layer=true
     sources: &mangohud-sources
       - type: archive
         url: https://github.com/flightlessmango/MangoHud/releases/download/v0.6.8/MangoHud-v0.6.8-Source.tar.xz

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -68,6 +68,8 @@ modules:
           version-query: |
             map(select(.tag_name | startswith("v"))) | first |
             .tag_name | sub("^[vV]"; "")
+      - type: patch
+        path: patches/Downgrade-required-meson-version-to-0.54.0.patch
     modules:
       - python3-mako.json
 

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -32,8 +32,8 @@ modules:
       - -Dappend_libdir_mangohud=false
     sources: &mangohud-sources
       - type: archive
-        url: https://github.com/flightlessmango/MangoHud/releases/download/v0.6.7-1/MangoHud-v0.6.7-1-Source.tar.xz
-        sha256: 5f925a537e611d898db608dd93155ce3c4137326b21376c7d34333181e3da959
+        url: https://github.com/flightlessmango/MangoHud/releases/download/v0.6.8/MangoHud-v0.6.8-Source.tar.xz
+        sha256: 9c64ccab1a72ba1dc61cb88d2fbcce1d343fc6b6cdf22c2cc2859bfb2da66fd4
         x-checker-data:
           type: json
           url: https://api.github.com/repos/flightlessmango/MangoHud/releases

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -35,6 +35,11 @@ x-arch-build-options:
       CXX: ccache i686-unknown-linux-gnu-g++
 cleanup:
   - /include
+  - /share/pkgconfig
+  - /lib/*/pkgconfig
+  - /lib/*/cmake
+  - /lib/*/*.a
+  - /lib/*/*.la
 modules:
 
   - name: MangoHud
@@ -66,6 +71,53 @@ modules:
     modules:
       - python3-mako.json
 
+      - name: glew
+        build-options: *x86_64-build-options
+        no-autogen: true
+        make-args: &glew-make-args
+          - GLEW_PREFIX=${FLATPAK_DEST}
+          - GLEW_DEST=${FLATPAK_DEST}
+          - LIBDIR=${FLATPAK_LIBDIR}
+          - PKGDIR=${FLATPAK_LIBDIR}/pkgconfig
+          - CFLAGS.EXTRA:=${CFLAGS} -fPIC
+          - LDFLAGS.EXTRA=${LDFLAGS}
+        make-install-args: *glew-make-args
+        sources: &glew-sources
+          - type: archive
+            url: https://downloads.sourceforge.net/project/glew/glew/2.2.0/glew-2.2.0.tgz
+            sha256: d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+        modules:
+          - name: glu
+            build-options: *x86_64-build-options
+            sources: &glu-sources
+              - type: archive
+                url: https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
+                sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
+
+      - name: glfw
+        build-options: *x86_64-build-options
+        buildsystem: cmake-ninja
+        config-opts: &glfw-config-opts
+          - -DGLFW_BUILD_EXAMPLES:BOOL=OFF
+          - -DGLFW_BUILD_TESTS:BOOL=OFF
+          - -DGLFW_BUILD_DOCS:BOOL=OFF
+        sources: &glfw-sources
+          - type: git
+            url: https://github.com/glfw/glfw.git
+            tag: 3.3.8
+            commit: 7482de6071d21db77a7236155da44c172a7f6c9e
+
+      - name: nlohmann-json
+        build-options: *x86_64-build-options
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DJSON_BuildTests:BOOL=OFF
+        sources:
+          - type: git
+            url: https://github.com/nlohmann/json.git
+            tag: v3.11.2
+            commit: bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d
+
       - name: libNVCtrl
         build-options: *x86_64-build-options
         no-autogen: true
@@ -94,6 +146,23 @@ modules:
     config-opts: *mangohud-config-opts
     sources: *mangohud-sources
     modules:
+
+      - name: glew-32bit
+        build-options: *i386-build-options
+        no-autogen: true
+        make-args: *glew-make-args
+        make-install-args: *glew-make-args
+        sources: *glew-sources
+        modules:
+          - name: glu-32bit
+            build-options: *i386-build-options
+            sources: *glu-sources
+
+      - name: glfw-32bit
+        build-options: *i386-build-options
+        buildsystem: cmake-ninja
+        config-opts: *glfw-config-opts
+        sources: *glfw-sources
 
       - name: libNVCtrl-32bit
         build-options: *i386-build-options

--- a/patches/Downgrade-required-meson-version-to-0.54.0.patch
+++ b/patches/Downgrade-required-meson-version-to-0.54.0.patch
@@ -1,0 +1,26 @@
+From f62faa1bf4cdd207fa7262e498d316926ceaaecd Mon Sep 17 00:00:00 2001
+From: guihkx <guihkx@users.noreply.github.com>
+Date: Wed, 26 Oct 2022 04:28:57 -0300
+Subject: [PATCH] Downgrade required meson version to 0.58.0
+
+This is necessary to build on the 21.08 branch.
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index e3e5813..fb71f58 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2,7 +2,7 @@ project('MangoHud',
+   ['c', 'cpp'],
+   version : 'v0.6.8',
+   license : 'MIT',
+-  meson_version: '>=0.60.0',
++  meson_version: '>=0.58.0',
+   default_options : ['buildtype=release', 'c_std=c99', 'cpp_std=c++14', 'warning_level=2']
+ )
+ 
+-- 
+2.38.1
+


### PR DESCRIPTION
This just syncs `branch/21.08` with `branch/22.08`, where the former still has MangoHud 0.6.7.