### PR TITLE
Update MangoHud 0.7.1

### DIFF
--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml
@@ -11,6 +11,7 @@
   <project_license>MIT</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="0.7.1" date="2024-02-08"/>
     <release version="0.7.0" date="2023-09-27"/>
     <release version="0.6.9-1" date="2023-04-17"/>
     <release version="0.6.9" date="2023-04-13"/>

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -59,8 +59,8 @@ modules:
       - -Dmangoapp_layer=true
     sources: &mangohud-sources
       - type: archive
-        url: https://github.com/flightlessmango/MangoHud/releases/download/v0.7.0/MangoHud-v0.7.0-Source.tar.xz
-        sha256: 05047cfdaf1668542e0c89bc999753ff8cea10b3d90f0a171788e5769a459832
+        url: https://github.com/flightlessmango/MangoHud/releases/download/v0.7.1/MangoHud-v0.7.1-1-Source.tar.xz
+        sha256: cfcc907c91b51f1fef4ec3f1cd52e2ff1b5caf207cdcff71869b94cefe39d208
         x-checker-data:
           type: json
           url: https://api.github.com/repos/flightlessmango/MangoHud/releases

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -43,7 +43,6 @@ cleanup:
   - /lib/*/cmake
   - /lib/*/*.a
   - /lib/*/*.la
-  - /bin/mangoplot
 modules:
 
   - name: MangoHud
@@ -57,6 +56,7 @@ modules:
       - -Dwith_xnvctrl=enabled
       - -Dappend_libdir_mangohud=false
       - -Dmangoapp_layer=true
+      - -Dmangoplot=disabled
     sources: &mangohud-sources
       - type: archive
         url: https://github.com/flightlessmango/MangoHud/releases/download/v0.7.1/MangoHud-v0.7.1-1-Source.tar.xz

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -70,10 +70,6 @@ modules:
           version-query: |
             map(select(.tag_name | startswith("v"))) | first |
             .tag_name | sub("^[vV]"; "")
-        # https://github.com/flightlessmango/MangoHud/commit/dc1761e98a435aaee6a919e21f43b85cc38500ac
-      - type: shell
-        commands:
-          - sed -i "s/, '-static-libstdc++'//" src/meson.build
     modules:
       - name: glew
         build-options: *x86_64-build-options


### PR DESCRIPTION
Update to MangoHud 0.7.1

Use the new build option introduced in this version to disable building mangoplot.

Revert bb26886fe9f2e96c367b599d7f9f736fd6a69017 from #35. It's been causing games to crash, confirmed with CS2 specifically, but I've had some other games crashing lately, and I believe this change could have been the cause all along. As it turns out, statically linking libstdc++ does matter even in Flatpak, because games are often executed under different runtimes, like the Steam runtimes.

Fixes bb26886fe9f2e96c367b599d7f9f736fd6a69017
Supersedes #39, #40, #41