### PR TITLE
Remove manual appstream compose step

### DIFF
--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -1,8 +1,8 @@
 id: org.freedesktop.Platform.VulkanLayer.MangoHud
-branch: '23.08'
+branch: "23.08"
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: "23.08"
 build-extension: true
 appstream-compose: false
 sdk-extensions:
@@ -44,7 +44,6 @@ cleanup:
   - /lib/*/*.a
   - /lib/*/*.la
 modules:
-
   - name: MangoHud
     build-options:
       arch:
@@ -148,7 +147,6 @@ modules:
     config-opts: *mangohud-config-opts
     sources: *mangohud-sources
     modules:
-
       - name: glew-32bit
         build-options:
           arch:

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -183,8 +183,9 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
-      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak
-        ${FLATPAK_ID}
+      - appstreamcli compose --components=${FLATPAK_ID} --prefix=/ --origin=${FLATPAK_ID}
+        --result-root=${FLATPAK_DEST} --data-dir=${FLATPAK_DEST}/share/app-info/xmls
+        ${FLATPAK_DEST}
     sources:
       - type: file
         path: org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -4,7 +4,6 @@ sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
 runtime-version: "23.08"
 build-extension: true
-appstream-compose: false
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
@@ -183,9 +182,6 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
-      - appstreamcli compose --components=${FLATPAK_ID} --prefix=/ --origin=${FLATPAK_ID}
-        --result-root=${FLATPAK_DEST} --data-dir=${FLATPAK_DEST}/share/app-info/xmls
-        ${FLATPAK_DEST}
     sources:
       - type: file
         path: org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml


### PR DESCRIPTION
`appstream-compose` will be dropped on Freedesktop SDK 24.08. We don't need to do that manually anymore, anyway.

>Flatpak-builder (>= 1.3.4) can compose metadata for extensions automatically and it is no longer required to manually compose them through commands in the manifest.

[https://docs.flatpak.org/en/latest/extension.html#extension-manifest](https://docs.flatpak.org/en/latest/extension.html#extension-manifest)

resolves #48