### PR TITLE
build: Fix warning from yaml parser

### DIFF
--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -102,7 +102,7 @@ modules:
         sources: &glfw-sources
           - type: git
             url: https://github.com/glfw/glfw.git
-            tag: 3.4
+            tag: '3.4'
             commit: 7b6aead9fb88b3623e3b3725ebb42670cbe4c579
 
       - name: nlohmann-json


### PR DESCRIPTION
`warning: '3.4' will be parsed as a number by many YAML parsers`  
Because yaml is garbage and we shouldn't be using it...