### PR TITLE
MangoHud: Update MangoHud-v0.8.0-Source.tar.xz to 0.8.1

### DIFF
--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.metainfo.xml
@@ -13,8 +13,11 @@
   <project_license>MIT</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="0.8.0" date="2025-02-11">
+    <release version="0.8.1" date="2025-03-05">
       <description></description>
+    </release>
+    <release version="0.8.0" date="2025-02-11">
+      <description/>
     </release>
     <release version="0.7.2" date="2024-05-26">
       <description/>

--- a/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
+++ b/org.freedesktop.Platform.VulkanLayer.MangoHud.yml
@@ -56,8 +56,8 @@ modules:
       - -Dmangoplot=disabled
     sources: &mangohud-sources
       - type: archive
-        url: https://github.com/flightlessmango/MangoHud/releases/download/v0.8.0/MangoHud-v0.8.0-Source.tar.xz
-        sha256: c860c733b1328f0fb479fc880281110799ebc13a4183033affc591c6d10719d9
+        url: https://github.com/flightlessmango/MangoHud/releases/download/v0.8.1/MangoHud-v0.8.1-Source.tar.xz
+        sha256: 4c8d8098f5deff7737978d792eef909b7469933f456a47132dccc06804825482
         x-checker-data:
           type: json
           url: https://api.github.com/repos/flightlessmango/MangoHud/releases


### PR DESCRIPTION
Apply update from #63 for runtime 23.08